### PR TITLE
Fix potential crash on `didEndDisplayingCell`

### DIFF
--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		578C820929EF6243008516C5 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578C820829EF6243008516C5 /* FeedLoaderCacheDecoratorTests.swift */; };
 		578C820B29EF65FE008516C5 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578C820A29EF65FE008516C5 /* FeedLoaderStub.swift */; };
 		578C820D29EF678A008516C5 /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578C820C29EF678A008516C5 /* XCTestCase+FeedLoader.swift */; };
+		578DAA502A09C2BB00BF1F77 /* UIView+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578DAA4F2A09C2BB00BF1F77 /* UIView+TestHelpers.swift */; };
 		57A0F9E129E4E2450029C3A5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0F9E029E4E2450029C3A5 /* AppDelegate.swift */; };
 		57A0F9E329E4E2450029C3A5 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0F9E229E4E2450029C3A5 /* SceneDelegate.swift */; };
 		57A0F9E529E4E2450029C3A5 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0F9E429E4E2450029C3A5 /* ViewController.swift */; };
@@ -102,6 +103,7 @@
 		578C820829EF6243008516C5 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		578C820A29EF65FE008516C5 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 		578C820C29EF678A008516C5 /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
+		578DAA4F2A09C2BB00BF1F77 /* UIView+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+TestHelpers.swift"; sourceTree = "<group>"; };
 		57A0F9DD29E4E2450029C3A5 /* EssentialApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EssentialApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		57A0F9E029E4E2450029C3A5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		57A0F9E229E4E2450029C3A5 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -220,6 +222,7 @@
 				571B9DFC2A0075F60086B2C9 /* UIRefreshControl+TestHelpers.swift */,
 				571B9DFF2A0075F60086B2C9 /* UIButton+TestHelpers.swift */,
 				571B9DFE2A0075F60086B2C9 /* UIControl+TestHelpers.swift */,
+				578DAA4F2A09C2BB00BF1F77 /* UIView+TestHelpers.swift */,
 				571B9DF82A0075F60086B2C9 /* FeedViewController+TestHelpers.swift */,
 				571B9E002A0075F60086B2C9 /* FeedImageCell+TestHelpers.swift */,
 				571B9DF92A0075F60086B2C9 /* FeedUIIntegrationTests+LoaderSpy.swift */,
@@ -378,6 +381,7 @@
 				57E691EF29E77E0F0084A963 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				571B9E0F2A0089330086B2C9 /* HTTPClientStub.swift in Sources */,
 				571B9E022A0075F60086B2C9 /* FeedImageCell+TestHelpers.swift in Sources */,
+				578DAA502A09C2BB00BF1F77 /* UIView+TestHelpers.swift in Sources */,
 				571B9E082A0075F60086B2C9 /* FeedViewController+TestHelpers.swift in Sources */,
 				578C820B29EF65FE008516C5 /* FeedLoaderStub.swift in Sources */,
 				571B9E0D2A0079FD0086B2C9 /* FeedAcceptanceTests.swift in Sources */,

--- a/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
@@ -62,6 +62,20 @@ final class FeedUIIntegrationTests: XCTestCase {
         assertThat(sut, isRendering: [image0, image1, image2, image3])
     }
     
+    func test_loadFeedCompletion_rendersSuccessfullyLoadedEmptyFeedAfterNonEmptyFeed() {
+        let image0 = makeImage()
+        let image1 = makeImage()
+        let (sut, loader) = makeSUT()
+        
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [image0, image1], at: 0)
+        assertThat(sut, isRendering: [image0, image1])
+        
+        sut.simulateUserInitiatedFeedReload()
+        loader.completeFeedLoading(with: [], at: 1)
+        assertThat(sut, isRendering: [])
+    }
+    
     func test_loadFeedCompletion_doesNotAlterCurrentRenderingStateOnError() {
         let image0 = makeImage()
         let (sut, loader) = makeSUT()

--- a/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
@@ -5,8 +5,7 @@ import EssentialFeediOS
 extension FeedUIIntegrationTests {
     
     func assertThat(_ sut: FeedViewController, isRendering feed: [FeedImage], file: StaticString = #file, line: UInt = #line) {
-        sut.tableView.layoutIfNeeded()
-        RunLoop.main.run(until: Date())
+        sut.view.enforceLayoutCycle()
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.", file: file, line: line)
         }

--- a/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
@@ -5,6 +5,8 @@ import EssentialFeediOS
 extension FeedUIIntegrationTests {
     
     func assertThat(_ sut: FeedViewController, isRendering feed: [FeedImage], file: StaticString = #file, line: UInt = #line) {
+        sut.tableView.layoutIfNeeded()
+        RunLoop.main.run(until: Date())
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.", file: file, line: line)
         }

--- a/EssentialApp/EssentialAppTests/Helpers/UIView+TestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/UIView+TestHelpers.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+extension UIView {
+    func enforceLayoutCycle() {
+        layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+    }
+}

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -9,6 +9,8 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
    
     @IBOutlet private(set) public var errorView: ErrorView?
     
+    private var loadingControllers = [IndexPath: FeedImageCellController]()
+    
     private var tableModel = [FeedImageCellController]() {
         didSet { tableView.reloadData() }
     }
@@ -32,6 +34,7 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     public func display(_ cellControllers: [FeedImageCellController]) {
+        loadingControllers = [:]
         tableModel = cellControllers
     }
     
@@ -66,10 +69,13 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     private func cellController(forRowAt indexPath: IndexPath) -> FeedImageCellController {
-        tableModel[indexPath.row]
+        let controller = tableModel[indexPath.row]
+        loadingControllers[indexPath] = controller
+        return controller
     }
     
     private func cancelCellControllerLoad(forRowAt indexPath: IndexPath) {
-        tableModel[indexPath.row].cancelLoad()
+        loadingControllers[indexPath]?.cancelLoad()
+        loadingControllers[indexPath] = nil
     }
 }

--- a/NOTES.md
+++ b/NOTES.md
@@ -2126,5 +2126,5 @@ T) test_loadFeedCompletion_rendersSuccessfullyLoadedEmptyFeedAfterNonEmptyFeed
 - and cancel will cancel that loadingController at that indexPath if any then set it to nil
 - set the reference in the 'cellController forRowAt' func
 [fix potential bug when cancelling requests in UITableView didEndDisplayingCell method - This method is invoked after calling `reloadData`, so we'd be cancelling requests in the wrong models or crash in case the model has less items than the previous model]
-- 
+[extract layout cycle steps into a shared helper extension]
 ```

--- a/NOTES.md
+++ b/NOTES.md
@@ -2111,3 +2111,20 @@ T) test_feedWithFailedImageLoading
 [move UIViewController snapshot helpers to separate file]
 [move `XCTestCase` snapshot helpers to separate file]
 ```
+
+### 6) Validating the UI with Snapshot Tests + Dark Mode Support
+```
+- fix issue when the system call didEndDisplaying (when reload data is called)
+- UIKit will call didEndDisplaying also when reloadData is called
+T) test_loadFeedCompletion_rendersSuccessfullyLoadedEmptyFeedAfterNonEmptyFeed
+- for persformance reason UIKit does not reload the table immediately after reloadData is called
+- in 'assertThat' func add tableView.layoutIfNeeded and RunLoop.main.run(unitl: Date()) -> Test crash
+- fix it adding a guard to check the tableModel count with the indexPath.row
+- but this doesnt solve the problem (will cancel the new image cell controllers) 
+- so create private var loadingControllers dictionary with keys IndexPath
+- every time we receive a new model we reset it (display func)
+- and cancel will cancel that loadingController at that indexPath if any then set it to nil
+- set the reference in the 'cellController forRowAt' func
+[fix potential bug when cancelling requests in UITableView didEndDisplayingCell method - This method is invoked after calling `reloadData`, so we'd be cancelling requests in the wrong models or crash in case the model has less items than the previous model]
+- 
+```


### PR DESCRIPTION
When updating the table model and reloading the table, UIKit calls didEndDisplayingCell for each removed cell that was previously visible. Since we're canceling requests in this method, we could be sending messages to the new models or potentially crashing in case the new table model has fewer items than the previous one!

This is not a big problem at the moment since items cannot be removed from the feed. But we cannot assume the backend will keep this behavior going further.