### PR TITLE
Guarantee Main Dispatch Queue on custom Scheduler

### DIFF
--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 				57A0F9E029E4E2450029C3A5 /* AppDelegate.swift */,
 				57A0F9E229E4E2450029C3A5 /* SceneDelegate.swift */,
 				571B9DEC2A00754E0086B2C9 /* FeedUIComposer.swift */,
+				5773C47B2A26BF2600BA4192 /* CombineHelpers.swift */,
 				571B9DF02A00754E0086B2C9 /* WeakRefVirtualProxy.swift */,
 				571B9DF12A00754E0086B2C9 /* FeedImageDataLoaderPresentationAdapter.swift */,
 				571B9DEF2A00754E0086B2C9 /* FeedLoaderPresentationAdapter.swift */,
@@ -163,7 +164,6 @@
 				57A0F9E929E4E2470029C3A5 /* Assets.xcassets */,
 				57A0F9EB29E4E2470029C3A5 /* LaunchScreen.storyboard */,
 				57A0F9EE29E4E2470029C3A5 /* Info.plist */,
-				5773C47B2A26BF2600BA4192 /* CombineHelpers.swift */,
 			);
 			path = EssentialApp;
 			sourceTree = "<group>";

--- a/EssentialApp/EssentialApp/CombineHelpers.swift
+++ b/EssentialApp/EssentialApp/CombineHelpers.swift
@@ -68,7 +68,7 @@ extension Publisher {
 
 extension DispatchQueue {
     static var immediateWhenOnMainQueueScheduler: ImmediateWhenOnMainQueueScheduler {
-        ImmediateWhenOnMainQueueScheduler()
+        ImmediateWhenOnMainQueueScheduler.shared
     }
     
     struct ImmediateWhenOnMainQueueScheduler: Scheduler {
@@ -83,8 +83,22 @@ extension DispatchQueue {
             DispatchQueue.main.minimumTolerance
         }
         
+        static let shared = Self()
+        
+        private static let key = DispatchSpecificKey<UInt8>()
+        private static let value = UInt8.max
+        
+        
+        private init() {
+            DispatchQueue.main.setSpecific(key: Self.key, value: Self.value)
+        }
+        
+        private func isMainQueue() -> Bool {
+            DispatchQueue.getSpecific(key: Self.key) == Self.value
+        }
+        
         func schedule(options: SchedulerOptions?, _ action: @escaping () -> Void) {
-            guard Thread.isMainThread else {
+            guard isMainQueue() else {
                 return DispatchQueue.main.schedule(options: options, action)
             }
             

--- a/NOTES.md
+++ b/NOTES.md
@@ -2337,3 +2337,27 @@ cacellable = feedLoader().sink(
 [move Combine helpers to a new file]
 [move dispatchOnMainQueue operator to the point of use (before subscription with `sink`)]
 ```
+
+```
+- the main thread can run queues that are not the Main Queue and some frameworks need to dispatch the
+- work to the main queue (main queue always runs in the main thread by the way) 
+- because of that it is not enough to check isMainThread 
+- to achieve this we can use an private isMainQueue function 
+- using the setSpecific(key: value:) 
+- and then with getSpecific(key) if it matched the value then we are in the same queue  
+private static let key = DispatchSpecificKey<UInt8> 
+private static let value = UInt8.max
+
+init() {
+    DispatchQueue.main.setSpecific(key: Self.key, value: Self.value)
+}
+
+private func isMainThread() -> Bool {
+    DispatchQueue.getSpecific(key: Self.key) == Self.value
+}
+
+- to prevent multiple instanciation of this class we can use a singlenton
+static let shared = Self()
+private init.. 
+[check isMainQueue instead of just isMainThread since there's no guarantee that the main thread is running the main queue]
+```


### PR DESCRIPTION
Check isMainQueue instead of just isMainThread since there's no guarantee that the main thread is running the main queue.